### PR TITLE
Fix code error in ResponseMessage

### DIFF
--- a/api/DSharpPlus.Interactivity.InteractivityConfiguration.html
+++ b/api/DSharpPlus.Interactivity.InteractivityConfiguration.html
@@ -350,7 +350,7 @@
   
   <a id="DSharpPlus_Interactivity_InteractivityConfiguration_ResponseMessage_" data-uid="DSharpPlus.Interactivity.InteractivityConfiguration.ResponseMessage*"></a>
   <h4 id="DSharpPlus_Interactivity_InteractivityConfiguration_ResponseMessage" data-uid="DSharpPlus.Interactivity.InteractivityConfiguration.ResponseMessage">ResponseMessage</h4>
-  <div class="markdown level1 summary"><p>The message to send to the user when processing invalid interactions. Ignored if <a class="xref" href="DSharpPlus.Interactivity.InteractivityConfiguration.html#DSharpPlus_Interactivity_InteractivityConfiguration_ResponseBehavior">ResponseBehavior</a> is not set to <see cref="!:InteractionResponseBehavior.Respond"></see>.</p>
+  <div class="markdown level1 summary"><p>The message to send to the user when processing invalid interactions. Ignored if <a class="xref" href="DSharpPlus.Interactivity.InteractivityConfiguration.html#DSharpPlus_Interactivity_InteractivityConfiguration_ResponseBehavior">ResponseBehavior</a> is not set to Respond.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>


### PR DESCRIPTION
There was a code error, which resulted in "Respond"  missing from ResponseBuilder description.